### PR TITLE
Update DiscussionCreated.php

### DIFF
--- a/src/Listeners/DiscussionCreated.php
+++ b/src/Listeners/DiscussionCreated.php
@@ -65,8 +65,7 @@ class DiscussionCreated
             ->get();
 
         $notify = $notify->filter(function (User $recipient) use ($discussion) {
-            return $recipient->can('subscribeDiscussionCreated') &&
-                $recipient->can('viewDiscussions', $discussion);
+            return $recipient->can('subscribeDiscussionCreated');
         });
 
         $this->notifications->sync(


### PR DESCRIPTION
According to the internet, the deleted line only returns true for admins in beta 10. Getting rid of it should enable everyone to receive notifications. I don't think we ever plan on hiding any discussions, so this *should* be fine.